### PR TITLE
AnimationNavigationRenderer as base class and accessing disposed object fixes

### DIFF
--- a/SourceCode/Lib/FormsControls.Droid/Renderers/AppCompatAnimationNavRenderer.cs
+++ b/SourceCode/Lib/FormsControls.Droid/Renderers/AppCompatAnimationNavRenderer.cs
@@ -43,11 +43,11 @@ namespace FormsControls.Droid
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
             if (Element != null)
             {
                 UnsubscribeFromNavigationEvents(Element);
             }
+            base.Dispose(disposing);
         }
 
         private void SubscribeToNavigationEvents(INavigationPageController page)

--- a/SourceCode/Lib/FormsControls.Touch/Renderers/AnimationNavigationRenderer.cs
+++ b/SourceCode/Lib/FormsControls.Touch/Renderers/AnimationNavigationRenderer.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Platform.iOS;
 
 namespace FormsControls.Touch
 {
-    internal class AnimationNavigationRenderer : NavigationRenderer
+    public class AnimationNavigationRenderer : NavigationRenderer
     {
         private readonly IPageAnimation _popToRootAnimation = new SlidePageAnimation();
         private readonly UISwipeGestureRecognizer _swipeLeftRecognizer;


### PR DESCRIPTION
Sometimes it is necceassry, especially when one uses an own renderer for navigationpages to be able to use the AnimationNavigationRenderer as a base class to still be able to benefit from the animations.

If base.Dispose() is called before unsubscribing from eventhandlers the Element will always be null and the handlers will be trying to access a disposed object.